### PR TITLE
Upgrade golang and docker base images version

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.6 as builder
+FROM golang:1.16.6 as builder
 
 WORKDIR /elrond
 COPY . .
@@ -9,7 +9,7 @@ RUN go build
 RUN cp /go/pkg/mod/github.com/!elrond!network/$(ls /go/pkg/mod/github.com/!elrond!network/ | grep arwen-wasm-vm | sed 's/.* //' | head -1)/wasmer/libwasmer_linux_amd64.so /lib/libwasmer_linux_amd64.so
 
 # ===== SECOND STAGE ======
-FROM ubuntu:18.04
+FROM ubuntu:21.04
 COPY --from=builder /elrond/cmd/proxy /elrond/cmd/proxy
 COPY --from=builder "/lib/libwasmer_linux_amd64.so" "/lib/libwasmer_linux_amd64.so"
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ The **Elrond Proxy** acts as an entry point into the Elrond Network.
 
 For more details, go to [docs.elrond.com](https://docs.elrond.com/sdk-and-tools/proxy/).
 
+Docker build instructions 
+
+```bash
+    git clone git@github.com:donutloop/elrond-proxy-go.git
+    cd elrond-proxy-go
+    docker build -f Docker/Dockerfile .
+```
+
 ## Rest API endpoints
 
 # V1.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ElrondNetwork/elrond-proxy-go
 
-go 1.13
+go 1.16
 
 require (
 	github.com/ElrondNetwork/elastic-indexer-go v1.0.0


### PR DESCRIPTION
"Golang: Although we expect that the vast majority of programs will maintain this
compatibility over time, it is impossible to guarantee that no future
change will break any program."

Ref: https://golang.org/doc/go1compat

* From Golang 1.13.6 to 1.16.6
* From ubuntu 18.04 to 21.04

Frequent Golang and docker upgrades are necessary to get rid of security issues