### PR TITLE
added address code-hash endpoint

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -59,6 +59,9 @@ var ErrValidation = errors.New("validation error")
 // ErrBadUrlParams signals one or more incorrectly provided URL params (generic error)
 var ErrBadUrlParams = errors.New("bad url parameter(s)")
 
+// ErrGetCodeHash signals an error in fetching the code hash for an account
+var ErrGetCodeHash = errors.New("cannot get code hash")
+
 // ErrValidationQueryParameterWithResult signals that an invalid query parameter has been provided
 var ErrValidationQueryParameterWithResult = errors.New("invalid query parameter withResults")
 

--- a/api/groups/baseAccountsGroup.go
+++ b/api/groups/baseAccountsGroup.go
@@ -33,6 +33,7 @@ func NewAccountsGroup(facadeHandler data.FacadeHandler) (*accountsGroup, error) 
 		{Path: "/:address/username", Handler: ag.getUsername, Method: http.MethodGet},
 		{Path: "/:address/nonce", Handler: ag.getNonce, Method: http.MethodGet},
 		{Path: "/:address/shard", Handler: ag.getShard, Method: http.MethodGet},
+		{Path: "/:address/code-hash", Handler: ag.getCodeHash, Method: http.MethodGet},
 		{Path: "/:address/transactions", Handler: ag.getTransactions, Method: http.MethodGet},
 		{Path: "/:address/keys", Handler: ag.getKeyValuePairs, Method: http.MethodGet},
 		{Path: "/:address/key/:key", Handler: ag.getValueForKey, Method: http.MethodGet},
@@ -104,6 +105,24 @@ func (group *accountsGroup) getNonce(c *gin.Context) {
 	group.respondWithAccount(c, func(model *data.AccountModel) gin.H {
 		return gin.H{"nonce": model.Account.Nonce, "blockInfo": model.BlockInfo}
 	})
+}
+
+// getCodeHash returns the code hash for the address parameter
+func (group *accountsGroup) getCodeHash(c *gin.Context) {
+	address := c.Param("address")
+	options, err := parseAccountQueryOptions(c)
+	if err != nil {
+		shared.RespondWithValidationError(c, errors.ErrBadUrlParams, err)
+		return
+	}
+
+	codeHashResponse, err := group.facade.GetCodeHash(address, options)
+	if err != nil {
+		shared.RespondWithInternalError(c, errors.ErrGetCodeHash, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, codeHashResponse)
 }
 
 // getTransactions returns the transactions for the address parameter

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -12,6 +12,7 @@ import (
 // AccountsFacadeHandler interface defines methods that can be used from the facade
 type AccountsFacadeHandler interface {
 	GetAccount(address string, options common.AccountQueryOptions) (*data.AccountModel, error)
+	GetCodeHash(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error)
 	GetTransactions(address string) ([]data.DatabaseTransaction, error)
 	GetShardIDForAddress(address string) (uint32, error)
 	GetValueForKey(address string, key string, options common.AccountQueryOptions) (string, error)

--- a/api/mock/facadeStub.go
+++ b/api/mock/facadeStub.go
@@ -76,6 +76,7 @@ type FacadeStub struct {
 	GetAlteredAccountsByHashCalled               func(shardID uint32, hash string, options common.GetAlteredAccountsForBlockOptions) (*data.AlteredAccountsApiResponse, error)
 	GetTriesStatisticsCalled                     func(shardID uint32) (*data.TrieStatisticsAPIResponse, error)
 	GetEpochStartDataCalled                      func(epoch uint32, shardID uint32) (*data.GenericAPIResponse, error)
+	GetCodeHashCalled                            func(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error)
 }
 
 // GetProof -
@@ -518,6 +519,11 @@ func (f *FacadeStub) GetEpochStartData(epoch uint32, shardID uint32) (*data.Gene
 // GetInternalStartOfEpochValidatorsInfo -
 func (f *FacadeStub) GetInternalStartOfEpochValidatorsInfo(epoch uint32) (*data.ValidatorsInfoApiResponse, error) {
 	return f.GetInternalStartOfEpochValidatorsInfoCalled(epoch)
+}
+
+// GetCodeHash -
+func (f *FacadeStub) GetCodeHash(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error) {
+	return f.GetCodeHashCalled(address, options)
 }
 
 // WrongFacade is a struct that can be used as a wrong implementation of the node router handler

--- a/cmd/proxy/config/apiConfig/v1_0.toml
+++ b/cmd/proxy/config/apiConfig/v1_0.toml
@@ -32,6 +32,7 @@ Routes = [
     { Name = "/:address/balance", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:address/nonce", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:address/username", Open = true, Secured = false, RateLimit = 0 },
+    { Name = "/:address/code-hash", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:address/keys", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:address/key/:key", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:address/esdt", Open = true, Secured = false, RateLimit = 0 },

--- a/cmd/proxy/config/apiConfig/v_next.toml
+++ b/cmd/proxy/config/apiConfig/v_next.toml
@@ -32,6 +32,7 @@ Routes = [
     { Name = "/:address/balance", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:address/nonce", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:address/username", Open = true, Secured = false, RateLimit = 0 },
+    { Name = "/:address/code-hash", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:address/keys", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:address/key/:key", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:address/esdt", Open = true, Secured = false, RateLimit = 0 },

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -131,6 +131,11 @@ func (epf *ProxyFacade) GetAccount(address string, options common.AccountQueryOp
 	return epf.accountProc.GetAccount(address, options)
 }
 
+// GetCodeHash returns the code hash for the given address
+func (epf *ProxyFacade) GetCodeHash(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error) {
+	return epf.accountProc.GetCodeHash(address, options)
+}
+
 // GetKeyValuePairs returns the key-value pairs for the given address
 func (epf *ProxyFacade) GetKeyValuePairs(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error) {
 	return epf.accountProc.GetKeyValuePairs(address, options)

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -29,6 +29,7 @@ type AccountProcessor interface {
 	GetESDTsRoles(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error)
 	GetESDTNftTokenData(address string, key string, nonce uint64, options common.AccountQueryOptions) (*data.GenericAPIResponse, error)
 	GetNFTTokenIDsRegisteredByAddress(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error)
+	GetCodeHash(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error)
 }
 
 // TransactionProcessor defines what a transaction request processor should do

--- a/facade/mock/accountProccessorStub.go
+++ b/facade/mock/accountProccessorStub.go
@@ -19,6 +19,7 @@ type AccountProcessorStub struct {
 	GetNFTTokenIDsRegisteredByAddressCalled func(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error)
 	GetKeyValuePairsCalled                  func(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error)
 	GetESDTsRolesCalled                     func(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error)
+	GetCodeHashCalled                       func(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error)
 }
 
 // GetKeyValuePairs -
@@ -78,6 +79,11 @@ func (aps *AccountProcessorStub) GetShardIDForAddress(address string) (uint32, e
 // GetTransactions --
 func (aps *AccountProcessorStub) GetTransactions(address string) ([]data.DatabaseTransaction, error) {
 	return aps.GetTransactionsCalled(address)
+}
+
+// GetCodeHash -
+func (aps *AccountProcessorStub) GetCodeHash(address string, options common.AccountQueryOptions) (*data.GenericAPIResponse, error) {
+	return aps.GetCodeHashCalled(address, options)
 }
 
 // ValidatorStatistics --

--- a/process/accountProcessor_test.go
+++ b/process/accountProcessor_test.go
@@ -148,7 +148,7 @@ func TestAccountProcessor_GetAccountSendingFailsOnFirstObserverShouldStillSend(t
 			GetObserversCalled: func(shardId uint32) (observers []*data.NodeData, e error) {
 				return []*data.NodeData{
 					{Address: addressFail, ShardId: 0},
-					{Address: "adress2", ShardId: 0},
+					{Address: "address2", ShardId: 0},
 				}, nil
 			},
 			CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
@@ -365,7 +365,7 @@ func TestAccountProcessor_GetESDTsWithRoleShouldWork(t *testing.T) {
 			},
 			GetObserversCalled: func(shardId uint32) (observers []*data.NodeData, e error) {
 				return []*data.NodeData{
-					{Address: "adress", ShardId: 0},
+					{Address: "address", ShardId: 0},
 				}, nil
 			},
 			CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
@@ -441,7 +441,7 @@ func TestAccountProcessor_GetESDTsRolesShouldWork(t *testing.T) {
 			},
 			GetObserversCalled: func(shardId uint32) (observers []*data.NodeData, e error) {
 				return []*data.NodeData{
-					{Address: "adress", ShardId: 0},
+					{Address: "address", ShardId: 0},
 				}, nil
 			},
 			CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
@@ -457,4 +457,32 @@ func TestAccountProcessor_GetESDTsRolesShouldWork(t *testing.T) {
 	response, err := ap.GetESDTsRoles(address, common.AccountQueryOptions{})
 	require.NoError(t, err)
 	require.Equal(t, "token0", response.Data.([]string)[0])
+}
+
+func TestAccountProcessor_GetCodeHash(t *testing.T) {
+	t.Parallel()
+
+	ap, _ := process.NewAccountProcessor(
+		&mock.ProcessorStub{
+			ComputeShardIdCalled: func(_ []byte) (u uint32, e error) {
+				return 0, nil
+			},
+			GetObserversCalled: func(shardId uint32) (observers []*data.NodeData, e error) {
+				return []*data.NodeData{
+					{Address: "address", ShardId: 0},
+				}, nil
+			},
+			CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
+				codeHashResponse := value.(*data.GenericAPIResponse)
+				codeHashResponse.Data = []string{"code-hash"}
+				return 0, nil
+			},
+		},
+		&mock.PubKeyConverterMock{},
+		database.NewDisabledElasticSearchConnector(),
+	)
+	address := "DEADBEEF"
+	response, err := ap.GetCodeHash(address, common.AccountQueryOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "code-hash", response.Data.([]string)[0])
 }


### PR DESCRIPTION
added the endpoint that exists on the node, but did not exist on proxy

**Testing procedure**
1). start a proxy by using this branch. 
2). find a smart contract, and call the following 2 endpoints:
- `<proxy>:<port>/address/erd1alice` 
- `<proxy>:<port>/address/erd1alice/code-hash`
The both of them should return the same code hash