### PR TITLE
fix esdt not found response

### DIFF
--- a/api/groups/baseAccountsGroup.go
+++ b/api/groups/baseAccountsGroup.go
@@ -233,7 +233,8 @@ func (group *accountsGroup) getESDTTokenData(c *gin.Context) {
 
 	esdtTokenResponse, err := group.facade.GetESDTTokenData(addr, tokenIdentifier, options)
 	if err != nil {
-		shared.RespondWithInternalError(c, errors.ErrEmptyTokenIdentifier, err)
+		shared.RespondWithInternalError(c, errors.ErrGetESDTTokenData, err)
+		return
 	}
 
 	c.JSON(http.StatusOK, esdtTokenResponse)


### PR DESCRIPTION
when an ESDT cannot be fetched, there was no `return` after writing the respone into `gin`, resulting in a non-JSON result