### PR TITLE
removed inconsistency check for repopulated tokens supply

### DIFF
--- a/process/errors.go
+++ b/process/errors.go
@@ -109,6 +109,3 @@ var ErrEmptyAppVersionString = errors.New("empty app version string")
 
 // ErrEmptyCommitString signals than an empty commit id string has been provided
 var ErrEmptyCommitString = errors.New("empty commit id string")
-
-// ErrInconsistentTokensSuppliesResponses signals an inconsistent response from the nodes
-var ErrInconsistentTokensSuppliesResponses = errors.New("inconsistent tokens supplies shard responses")

--- a/process/esdtSupplyProcessor.go
+++ b/process/esdtSupplyProcessor.go
@@ -103,14 +103,6 @@ func (esp *esdtSupplyProcessor) getSupplyFromShards(tokenIdentifier string) (*da
 	}
 
 	if numNodesWithRecomputedSupply > 0 {
-		if numNodesWithRecomputedSupply != numNodesQueried {
-			// this means that some nodes have recomputed supply and some don't
-			log.Error("inconsistent observers setup: some nodes have recomputed supply and some don't",
-				"numNodesWithRecomputedSupply", numNodesWithRecomputedSupply,
-				"numNodesQueried", numNodesQueried)
-			return nil, ErrInconsistentTokensSuppliesResponses
-		}
-
 		totalSupply.RecomputedSupply = true
 	}
 

--- a/process/esdtSupplyProcessor_test.go
+++ b/process/esdtSupplyProcessor_test.go
@@ -120,63 +120,6 @@ func TestEsdtSupplyProcessor_GetESDTSupplyNonFungible(t *testing.T) {
 	require.Equal(t, "0", supplyRes.Data.InitialMinted)
 }
 
-func TestEsdtSupplyProcessor_GetESDTSupplyShouldReturnErrorIfInconsistentResponses(t *testing.T) {
-	t.Parallel()
-
-	called := false
-	baseProc := &mock.ProcessorStub{
-		GetShardIDsCalled: func() []uint32 {
-			return []uint32{0, 1, core.MetachainShardId}
-		},
-		GetObserversCalled: func(shardID uint32) ([]*data.NodeData, error) {
-			return []*data.NodeData{
-				{
-					ShardId: shardID,
-					Address: fmt.Sprintf("shard-%d", shardID),
-				},
-				{
-					ShardId: shardID,
-					Address: fmt.Sprintf("shard-%d", shardID),
-				},
-			}, nil
-		},
-		CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
-			switch address {
-			case "shard-0":
-				if !called {
-					called = true
-					return 400, errors.New("local err")
-				}
-				valResp := value.(*data.ESDTSupplyResponse)
-				valResp.Data.Supply = "300"
-				valResp.Data.RecomputedSupply = true
-				return 200, nil
-			case "shard-1":
-				valResp := value.(*data.ESDTSupplyResponse)
-				valResp.Data.Supply = "600"
-				valResp.Data.Minted = "50"
-				valResp.Data.Burned = "100"
-				valResp.Data.RecomputedSupply = false
-				return 200, nil
-			}
-			return 0, nil
-		},
-	}
-	scQueryProc := &mock.SCQueryServiceStub{
-		ExecuteQueryCalled: func(query *data.SCQuery) (*vm.VMOutputApi, data.BlockInfo, error) {
-			return &vm.VMOutputApi{
-				ReturnData: [][]byte{nil, nil, nil, []byte("500")},
-			}, data.BlockInfo{}, nil
-		},
-	}
-	esdtProc, err := NewESDTSupplyProcessor(baseProc, scQueryProc)
-	require.Nil(t, err)
-
-	supplyRes, err := esdtProc.GetESDTSupply("SEMI-ABCDEF")
-	require.Empty(t, supplyRes)
-	require.Equal(t, ErrInconsistentTokensSuppliesResponses, err)
-}
-
 func TestEsdtSupplyProcessor_GetESDTSupplyShouldReturnRecomputed(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
this check would have raised false positives when not all shards contained data about a given token