### PR TITLE
update go builder in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.6 as builder
+FROM golang:1.20.7 as builder
 
 WORKDIR /mx-chain-proxy-go
 COPY . .


### PR DESCRIPTION
the Docker build failed because of the old go version:
https://github.com/multiversx/mx-chain-proxy-go/actions/runs/7195462065