### PR TITLE
remove swagger servers list

### DIFF
--- a/cmd/proxy/config/swagger/openapi.json
+++ b/cmd/proxy/config/swagger/openapi.json
@@ -2651,17 +2651,7 @@
     "description": "MultiversX Docs",
     "url": "https://docs.multiversx.com"
   },
-  "servers": [
-    {
-      "url": "https://testnet-gateway.multiversx.com"
-    },
-    {
-      "url": "https://devnet-gateway.multiversx.com"
-    },
-    {
-      "url": "https://gateway.multiversx.com"
-    }
-  ],
+  "servers": [],
   "components": {
     "requestBodies": {
       "Transaction": {


### PR DESCRIPTION
Previously, the servers list was hardcoded into the open api specs and users had to select the correct server when using the Swagger UI. Furthermore, without file change, a local copy of the proxy could have not been tested. Removed the servers list so Swagger will make all calls to the current host.

**Testing procedure**:
- `./proxy --start-swagger-ui`
- navigate to `localhost:8080` (or any other host the proxy is deployed to) and all the queries should trigger that proxy instance. also, the server list should not be visible anymore