### PR TITLE
New endpoint /transaction/pool/count

### DIFF
--- a/api/groups/baseTransactionGroup.go
+++ b/api/groups/baseTransactionGroup.go
@@ -415,23 +415,21 @@ func getTxPoolForSender(c *gin.Context, ef TransactionFacadeHandler, sender, fie
 	shared.RespondWith(c, http.StatusOK, gin.H{"txPool": txPool}, "", data.ReturnCodeSuccess)
 }
 
-func getTxPoolCount(c *gin.Context, ef TransactionFacadeHandler, shardID uint32) {
-	txPoolCount, err := ef.GetTransactionsPoolCount(shardID)
+// getTransactionsPoolCount will return the number of transactions currently in the pool.
+// If a shard-id url param is provided, it returns the count only for that shard,
+// otherwise it returns the counts for every shard.
+func (group *transactionGroup) getTransactionsPoolCount(c *gin.Context) {
+	shardIDParam, err := parseUint32UrlParam(c, common.UrlParameterShardID)
+	if err != nil {
+		shared.RespondWith(c, http.StatusBadRequest, nil, errors.ErrBadUrlParams.Error(), data.ReturnCodeRequestError)
+		return
+	}
+
+	txPoolCounts, err := group.facade.GetTransactionsPoolCounts(shardIDParam)
 	if err != nil {
 		shared.RespondWith(c, http.StatusInternalServerError, nil, err.Error(), data.ReturnCodeInternalError)
 		return
 	}
 
-	shared.RespondWith(c, http.StatusOK, gin.H{"txPoolCount": txPoolCount}, "", data.ReturnCodeSuccess)
-}
-
-// getTransactionsPoolCount will return the number of transactions currently in the pool for the given shard
-func (group *transactionGroup) getTransactionsPoolCount(c *gin.Context) {
-	shardIDParam, err := parseUint32UrlParam(c, common.UrlParameterShardID)
-	if err != nil || !shardIDParam.HasValue {
-		shared.RespondWith(c, http.StatusBadRequest, nil, errors.ErrBadUrlParams.Error(), data.ReturnCodeRequestError)
-		return
-	}
-
-	getTxPoolCount(c, group.facade, shardIDParam.Value)
+	shared.RespondWith(c, http.StatusOK, gin.H{"txPoolCounts": txPoolCounts}, "", data.ReturnCodeSuccess)
 }

--- a/api/groups/baseTransactionGroup.go
+++ b/api/groups/baseTransactionGroup.go
@@ -39,6 +39,7 @@ func NewTransactionGroup(facadeHandler data.FacadeHandler) (*transactionGroup, e
 		{Path: "/:txhash/process-status", Handler: tg.getProcessedTransactionStatus, Method: http.MethodGet},
 		{Path: "/:txhash", Handler: tg.getTransaction, Method: http.MethodGet},
 		{Path: "/pool", Handler: tg.getTransactionsPool, Method: http.MethodGet},
+		{Path: "/pool/count", Handler: tg.getTransactionsPoolCount, Method: http.MethodGet},
 	}
 	tg.baseGroup.endpoints = baseRoutesHandlers
 
@@ -412,4 +413,25 @@ func getTxPoolForSender(c *gin.Context, ef TransactionFacadeHandler, sender, fie
 	}
 
 	shared.RespondWith(c, http.StatusOK, gin.H{"txPool": txPool}, "", data.ReturnCodeSuccess)
+}
+
+func getTxPoolCount(c *gin.Context, ef TransactionFacadeHandler, shardID uint32) {
+	txPoolCount, err := ef.GetTransactionsPoolCount(shardID)
+	if err != nil {
+		shared.RespondWith(c, http.StatusInternalServerError, nil, err.Error(), data.ReturnCodeInternalError)
+		return
+	}
+
+	shared.RespondWith(c, http.StatusOK, gin.H{"txPoolCount": txPoolCount}, "", data.ReturnCodeSuccess)
+}
+
+// getTransactionsPoolCount will return the number of transactions currently in the pool for the given shard
+func (group *transactionGroup) getTransactionsPoolCount(c *gin.Context) {
+	shardIDParam, err := parseUint32UrlParam(c, common.UrlParameterShardID)
+	if err != nil || !shardIDParam.HasValue {
+		shared.RespondWith(c, http.StatusBadRequest, nil, errors.ErrBadUrlParams.Error(), data.ReturnCodeRequestError)
+		return
+	}
+
+	getTxPoolCount(c, group.facade, shardIDParam.Value)
 }

--- a/api/groups/baseTransactionGroup_test.go
+++ b/api/groups/baseTransactionGroup_test.go
@@ -71,6 +71,15 @@ type nonceGapsResp struct {
 	Data nonceGaps
 }
 
+type txPoolCount struct {
+	TxPoolCount uint64 `json:"txPoolCount"`
+}
+
+type txPoolCountResp struct {
+	GeneralResponse
+	Data txPoolCount
+}
+
 type txProcessedStatusResp struct {
 	GeneralResponse
 	Data struct {
@@ -749,6 +758,100 @@ func TestGetTransactionsPoolPoolNonceGapsForSender_ReturnsSuccessfully(t *testin
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.Equal(t, response.Error, "")
 	assert.Equal(t, providedNonceGaps, &response.Data.NonceGaps)
+}
+
+func TestGetTransactionsPoolCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing shard-id param should err", func(t *testing.T) {
+		t.Parallel()
+
+		transactionsGroup, err := groups.NewTransactionGroup(&mock.FacadeStub{})
+		require.NoError(t, err)
+		ws := startProxyServer(transactionsGroup, transactionsPath)
+
+		req, _ := http.NewRequest("GET", "/transaction/pool/count", nil)
+
+		resp := httptest.NewRecorder()
+		ws.ServeHTTP(resp, req)
+
+		response := GeneralResponse{}
+		loadResponse(resp.Body, &response)
+
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, apiErrors.ErrBadUrlParams.Error(), response.Error)
+	})
+	t.Run("invalid shard-id param should err", func(t *testing.T) {
+		t.Parallel()
+
+		transactionsGroup, err := groups.NewTransactionGroup(&mock.FacadeStub{})
+		require.NoError(t, err)
+		ws := startProxyServer(transactionsGroup, transactionsPath)
+
+		req, _ := http.NewRequest("GET", "/transaction/pool/count?shard-id=invalid", nil)
+
+		resp := httptest.NewRecorder()
+		ws.ServeHTTP(resp, req)
+
+		response := GeneralResponse{}
+		loadResponse(resp.Body, &response)
+
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, apiErrors.ErrBadUrlParams.Error(), response.Error)
+	})
+	t.Run("facade error should err", func(t *testing.T) {
+		t.Parallel()
+
+		expectedErr := errors.New("facade error")
+		facade := &mock.FacadeStub{
+			GetTransactionsPoolCountHandler: func(shardID uint32) (uint64, error) {
+				assert.Equal(t, uint32(0), shardID)
+				return 0, expectedErr
+			},
+		}
+
+		transactionsGroup, err := groups.NewTransactionGroup(facade)
+		require.NoError(t, err)
+		ws := startProxyServer(transactionsGroup, transactionsPath)
+
+		req, _ := http.NewRequest("GET", "/transaction/pool/count?shard-id=0", nil)
+
+		resp := httptest.NewRecorder()
+		ws.ServeHTTP(resp, req)
+
+		response := GeneralResponse{}
+		loadResponse(resp.Body, &response)
+
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.Equal(t, expectedErr.Error(), response.Error)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		providedCount := uint64(42)
+		facade := &mock.FacadeStub{
+			GetTransactionsPoolCountHandler: func(shardID uint32) (uint64, error) {
+				assert.Equal(t, uint32(1), shardID)
+				return providedCount, nil
+			},
+		}
+
+		transactionsGroup, err := groups.NewTransactionGroup(facade)
+		require.NoError(t, err)
+		ws := startProxyServer(transactionsGroup, transactionsPath)
+
+		req, _ := http.NewRequest("GET", "/transaction/pool/count?shard-id=1", nil)
+
+		resp := httptest.NewRecorder()
+		ws.ServeHTTP(resp, req)
+
+		response := txPoolCountResp{}
+		loadResponse(resp.Body, &response)
+
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, "", response.Error)
+		assert.Equal(t, providedCount, response.Data.TxPoolCount)
+	})
 }
 
 func TestTransactionGroup_getProcessedTransactionStatus(t *testing.T) {

--- a/api/groups/baseTransactionGroup_test.go
+++ b/api/groups/baseTransactionGroup_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/multiversx/mx-chain-core-go/core"
 	apiErrors "github.com/multiversx/mx-chain-proxy-go/api/errors"
 	"github.com/multiversx/mx-chain-proxy-go/api/groups"
 	"github.com/multiversx/mx-chain-proxy-go/api/mock"
@@ -71,13 +72,13 @@ type nonceGapsResp struct {
 	Data nonceGaps
 }
 
-type txPoolCount struct {
-	TxPoolCount uint64 `json:"txPoolCount"`
+type txPoolCounts struct {
+	TxPoolCounts map[string]uint64 `json:"txPoolCounts"`
 }
 
-type txPoolCountResp struct {
+type txPoolCountsResp struct {
 	GeneralResponse
-	Data txPoolCount
+	Data txPoolCounts
 }
 
 type txProcessedStatusResp struct {
@@ -760,27 +761,9 @@ func TestGetTransactionsPoolPoolNonceGapsForSender_ReturnsSuccessfully(t *testin
 	assert.Equal(t, providedNonceGaps, &response.Data.NonceGaps)
 }
 
-func TestGetTransactionsPoolCount(t *testing.T) {
+func TestGetTransactionsPoolCounts(t *testing.T) {
 	t.Parallel()
 
-	t.Run("missing shard-id param should err", func(t *testing.T) {
-		t.Parallel()
-
-		transactionsGroup, err := groups.NewTransactionGroup(&mock.FacadeStub{})
-		require.NoError(t, err)
-		ws := startProxyServer(transactionsGroup, transactionsPath)
-
-		req, _ := http.NewRequest("GET", "/transaction/pool/count", nil)
-
-		resp := httptest.NewRecorder()
-		ws.ServeHTTP(resp, req)
-
-		response := GeneralResponse{}
-		loadResponse(resp.Body, &response)
-
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
-		assert.Equal(t, apiErrors.ErrBadUrlParams.Error(), response.Error)
-	})
 	t.Run("invalid shard-id param should err", func(t *testing.T) {
 		t.Parallel()
 
@@ -804,9 +787,10 @@ func TestGetTransactionsPoolCount(t *testing.T) {
 
 		expectedErr := errors.New("facade error")
 		facade := &mock.FacadeStub{
-			GetTransactionsPoolCountHandler: func(shardID uint32) (uint64, error) {
-				assert.Equal(t, uint32(0), shardID)
-				return 0, expectedErr
+			GetTransactionsPoolCountsHandler: func(shardIDParam core.OptionalUint32) (map[uint32]uint64, error) {
+				require.True(t, shardIDParam.HasValue)
+				assert.Equal(t, uint32(0), shardIDParam.Value)
+				return nil, expectedErr
 			},
 		}
 
@@ -825,14 +809,15 @@ func TestGetTransactionsPoolCount(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, resp.Code)
 		assert.Equal(t, expectedErr.Error(), response.Error)
 	})
-	t.Run("should work", func(t *testing.T) {
+	t.Run("should work for single shard", func(t *testing.T) {
 		t.Parallel()
 
-		providedCount := uint64(42)
+		providedCounts := map[uint32]uint64{1: 42}
 		facade := &mock.FacadeStub{
-			GetTransactionsPoolCountHandler: func(shardID uint32) (uint64, error) {
-				assert.Equal(t, uint32(1), shardID)
-				return providedCount, nil
+			GetTransactionsPoolCountsHandler: func(shardIDParam core.OptionalUint32) (map[uint32]uint64, error) {
+				require.True(t, shardIDParam.HasValue)
+				assert.Equal(t, uint32(1), shardIDParam.Value)
+				return providedCounts, nil
 			},
 		}
 
@@ -845,12 +830,67 @@ func TestGetTransactionsPoolCount(t *testing.T) {
 		resp := httptest.NewRecorder()
 		ws.ServeHTTP(resp, req)
 
-		response := txPoolCountResp{}
+		response := txPoolCountsResp{}
 		loadResponse(resp.Body, &response)
 
 		assert.Equal(t, http.StatusOK, resp.Code)
 		assert.Equal(t, "", response.Error)
-		assert.Equal(t, providedCount, response.Data.TxPoolCount)
+		assert.Equal(t, uint64(42), response.Data.TxPoolCounts["1"])
+	})
+	t.Run("facade error for all shards should err", func(t *testing.T) {
+		t.Parallel()
+
+		expectedErr := errors.New("facade error")
+		facade := &mock.FacadeStub{
+			GetTransactionsPoolCountsHandler: func(shardIDParam core.OptionalUint32) (map[uint32]uint64, error) {
+				require.False(t, shardIDParam.HasValue)
+				return nil, expectedErr
+			},
+		}
+
+		transactionsGroup, err := groups.NewTransactionGroup(facade)
+		require.NoError(t, err)
+		ws := startProxyServer(transactionsGroup, transactionsPath)
+
+		req, _ := http.NewRequest("GET", "/transaction/pool/count", nil)
+
+		resp := httptest.NewRecorder()
+		ws.ServeHTTP(resp, req)
+
+		response := GeneralResponse{}
+		loadResponse(resp.Body, &response)
+
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.Equal(t, expectedErr.Error(), response.Error)
+	})
+	t.Run("should work for all shards", func(t *testing.T) {
+		t.Parallel()
+
+		providedCounts := map[uint32]uint64{0: 10, 1: 42, 2: 7}
+		facade := &mock.FacadeStub{
+			GetTransactionsPoolCountsHandler: func(shardIDParam core.OptionalUint32) (map[uint32]uint64, error) {
+				require.False(t, shardIDParam.HasValue)
+				return providedCounts, nil
+			},
+		}
+
+		transactionsGroup, err := groups.NewTransactionGroup(facade)
+		require.NoError(t, err)
+		ws := startProxyServer(transactionsGroup, transactionsPath)
+
+		req, _ := http.NewRequest("GET", "/transaction/pool/count", nil)
+
+		resp := httptest.NewRecorder()
+		ws.ServeHTTP(resp, req)
+
+		response := txPoolCountsResp{}
+		loadResponse(resp.Body, &response)
+
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, "", response.Error)
+		assert.Equal(t, uint64(10), response.Data.TxPoolCounts["0"])
+		assert.Equal(t, uint64(42), response.Data.TxPoolCounts["1"])
+		assert.Equal(t, uint64(7), response.Data.TxPoolCounts["2"])
 	})
 }
 

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -3,6 +3,7 @@ package groups
 import (
 	"math/big"
 
+	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/data/vm"
 	"github.com/multiversx/mx-chain-proxy-go/common"
@@ -105,7 +106,7 @@ type TransactionFacadeHandler interface {
 	GetTransactionsPoolForSender(sender, fields string) (*data.TransactionsPoolForSender, error)
 	GetLastPoolNonceForSender(sender string) (uint64, error)
 	GetTransactionsPoolNonceGapsForSender(sender string) (*data.TransactionsPoolNonceGaps, error)
-	GetTransactionsPoolCount(shardID uint32) (uint64, error)
+	GetTransactionsPoolCounts(shardIDParam core.OptionalUint32) (map[uint32]uint64, error)
 }
 
 // ProofFacadeHandler interface defines methods that can be used from the facade

--- a/api/groups/interface.go
+++ b/api/groups/interface.go
@@ -105,6 +105,7 @@ type TransactionFacadeHandler interface {
 	GetTransactionsPoolForSender(sender, fields string) (*data.TransactionsPoolForSender, error)
 	GetLastPoolNonceForSender(sender string) (uint64, error)
 	GetTransactionsPoolNonceGapsForSender(sender string) (*data.TransactionsPoolNonceGaps, error)
+	GetTransactionsPoolCount(shardID uint32) (uint64, error)
 }
 
 // ProofFacadeHandler interface defines methods that can be used from the facade

--- a/api/mock/facadeStub.go
+++ b/api/mock/facadeStub.go
@@ -30,6 +30,7 @@ type FacadeStub struct {
 	GetTransactionsPoolForSenderHandler          func(sender, fields string) (*data.TransactionsPoolForSender, error)
 	GetLastPoolNonceForSenderHandler             func(sender string) (uint64, error)
 	GetTransactionsPoolNonceGapsForSenderHandler func(sender string) (*data.TransactionsPoolNonceGaps, error)
+	GetTransactionsPoolCountHandler              func(shardID uint32) (uint64, error)
 	SendTransactionHandler                       func(tx *data.Transaction) (int, string, error)
 	SendMultipleTransactionsHandler              func(txs []*data.Transaction) (data.MultipleTransactionsResponseData, error)
 	SimulateTransactionHandler                   func(tx *data.Transaction, checkSignature bool) (*data.GenericAPIResponse, error)
@@ -403,6 +404,15 @@ func (f *FacadeStub) GetTransactionsPoolNonceGapsForSender(sender string) (*data
 	}
 
 	return nil, nil
+}
+
+// GetTransactionsPoolCount -
+func (f *FacadeStub) GetTransactionsPoolCount(shardID uint32) (uint64, error) {
+	if f.GetTransactionsPoolCountHandler != nil {
+		return f.GetTransactionsPoolCountHandler(shardID)
+	}
+
+	return 0, nil
 }
 
 // SendTransaction -

--- a/api/mock/facadeStub.go
+++ b/api/mock/facadeStub.go
@@ -30,7 +30,7 @@ type FacadeStub struct {
 	GetTransactionsPoolForSenderHandler          func(sender, fields string) (*data.TransactionsPoolForSender, error)
 	GetLastPoolNonceForSenderHandler             func(sender string) (uint64, error)
 	GetTransactionsPoolNonceGapsForSenderHandler func(sender string) (*data.TransactionsPoolNonceGaps, error)
-	GetTransactionsPoolCountHandler              func(shardID uint32) (uint64, error)
+	GetTransactionsPoolCountsHandler             func(shardIDParam core.OptionalUint32) (map[uint32]uint64, error)
 	SendTransactionHandler                       func(tx *data.Transaction) (int, string, error)
 	SendMultipleTransactionsHandler              func(txs []*data.Transaction) (data.MultipleTransactionsResponseData, error)
 	SimulateTransactionHandler                   func(tx *data.Transaction, checkSignature bool) (*data.GenericAPIResponse, error)
@@ -406,13 +406,13 @@ func (f *FacadeStub) GetTransactionsPoolNonceGapsForSender(sender string) (*data
 	return nil, nil
 }
 
-// GetTransactionsPoolCount -
-func (f *FacadeStub) GetTransactionsPoolCount(shardID uint32) (uint64, error) {
-	if f.GetTransactionsPoolCountHandler != nil {
-		return f.GetTransactionsPoolCountHandler(shardID)
+// GetTransactionsPoolCounts -
+func (f *FacadeStub) GetTransactionsPoolCounts(shardIDParam core.OptionalUint32) (map[uint32]uint64, error) {
+	if f.GetTransactionsPoolCountsHandler != nil {
+		return f.GetTransactionsPoolCountsHandler(shardIDParam)
 	}
 
-	return 0, nil
+	return make(map[uint32]uint64), nil
 }
 
 // SendTransaction -

--- a/cmd/proxy/config/apiConfig/v1_0.toml
+++ b/cmd/proxy/config/apiConfig/v1_0.toml
@@ -102,7 +102,8 @@ Routes = [
     { Name = "/:txhash", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:txhash/status", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:txhash/process-status", Open = true, Secured = false, RateLimit = 0 },
-    { Name = "/pool", Open = true, Secured = false, RateLimit = 0 }
+    { Name = "/pool", Open = true, Secured = false, RateLimit = 0 },
+    { Name = "/pool/count", Open = true, Secured = false, RateLimit = 0 }
 ]
 
 [APIPackages.block]

--- a/cmd/proxy/config/apiConfig/v_next.toml
+++ b/cmd/proxy/config/apiConfig/v_next.toml
@@ -102,7 +102,8 @@ Routes = [
     { Name = "/:txhash", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:txhash/status", Open = true, Secured = false, RateLimit = 0 },
     { Name = "/:txhash/process-status", Open = true, Secured = false, RateLimit = 0 },
-    { Name = "/pool", Open = true, Secured = false, RateLimit = 0 }
+    { Name = "/pool", Open = true, Secured = false, RateLimit = 0 },
+    { Name = "/pool/count", Open = true, Secured = false, RateLimit = 0 }
 ]
 
 [APIPackages.block]

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -535,9 +535,11 @@ func (pf *ProxyFacade) GetTriesStatistics(shardID uint32) (*data.TrieStatisticsA
 	return pf.nodeStatusProc.GetTriesStatistics(shardID)
 }
 
-// GetTransactionsPoolCount will return the number of transactions currently in the pool for the given shard
-func (pf *ProxyFacade) GetTransactionsPoolCount(shardID uint32) (uint64, error) {
-	return pf.nodeStatusProc.GetTransactionsPoolCount(shardID)
+// GetTransactionsPoolCounts will return the number of transactions currently in the pool.
+// If shardIDParam has a value, it returns the count only for the provided shard,
+// otherwise it returns the counts for every shard.
+func (pf *ProxyFacade) GetTransactionsPoolCounts(shardIDParam core.OptionalUint32) (map[uint32]uint64, error) {
+	return pf.nodeStatusProc.GetTransactionsPoolCounts(shardIDParam)
 }
 
 // GetEpochStartData retrieves epoch start data for the provides epoch and shard ID

--- a/facade/baseFacade.go
+++ b/facade/baseFacade.go
@@ -535,6 +535,11 @@ func (pf *ProxyFacade) GetTriesStatistics(shardID uint32) (*data.TrieStatisticsA
 	return pf.nodeStatusProc.GetTriesStatistics(shardID)
 }
 
+// GetTransactionsPoolCount will return the number of transactions currently in the pool for the given shard
+func (pf *ProxyFacade) GetTransactionsPoolCount(shardID uint32) (uint64, error) {
+	return pf.nodeStatusProc.GetTransactionsPoolCount(shardID)
+}
+
 // GetEpochStartData retrieves epoch start data for the provides epoch and shard ID
 func (pf *ProxyFacade) GetEpochStartData(epoch uint32, shardID uint32) (*data.GenericAPIResponse, error) {
 	return pf.nodeStatusProc.GetEpochStartData(epoch, shardID)

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -102,6 +102,7 @@ type NodeStatusProcessor interface {
 	GetGasConfigs() (*data.GenericAPIResponse, error)
 	GetTriesStatistics(shardID uint32) (*data.TrieStatisticsAPIResponse, error)
 	GetEpochStartData(epoch uint32, shardID uint32) (*data.GenericAPIResponse, error)
+	GetTransactionsPoolCount(shardID uint32) (uint64, error)
 }
 
 // BlocksProcessor defines what a blocks processor should do

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -3,6 +3,7 @@ package facade
 import (
 	"math/big"
 
+	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/data/vm"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
@@ -102,7 +103,7 @@ type NodeStatusProcessor interface {
 	GetGasConfigs() (*data.GenericAPIResponse, error)
 	GetTriesStatistics(shardID uint32) (*data.TrieStatisticsAPIResponse, error)
 	GetEpochStartData(epoch uint32, shardID uint32) (*data.GenericAPIResponse, error)
-	GetTransactionsPoolCount(shardID uint32) (uint64, error)
+	GetTransactionsPoolCounts(shardIDParam core.OptionalUint32) (map[uint32]uint64, error)
 }
 
 // BlocksProcessor defines what a blocks processor should do

--- a/facade/mock/nodeStatusProcessorStub.go
+++ b/facade/mock/nodeStatusProcessorStub.go
@@ -19,6 +19,7 @@ type NodeStatusProcessorStub struct {
 	GetGasConfigsCalled                             func() (*data.GenericAPIResponse, error)
 	GetTriesStatisticsCalled                        func(shardID uint32) (*data.TrieStatisticsAPIResponse, error)
 	GetEpochStartDataCalled                         func(epoch uint32, shardID uint32) (*data.GenericAPIResponse, error)
+	GetTransactionsPoolCountCalled                  func(shardID uint32) (uint64, error)
 }
 
 // GetNetworkConfigMetrics --
@@ -153,4 +154,12 @@ func (stub *NodeStatusProcessorStub) GetTriesStatistics(shardID uint32) (*data.T
 		return stub.GetTriesStatisticsCalled(shardID)
 	}
 	return &data.TrieStatisticsAPIResponse{}, nil
+}
+
+// GetTransactionsPoolCount -
+func (stub *NodeStatusProcessorStub) GetTransactionsPoolCount(shardID uint32) (uint64, error) {
+	if stub.GetTransactionsPoolCountCalled != nil {
+		return stub.GetTransactionsPoolCountCalled(shardID)
+	}
+	return 0, nil
 }

--- a/facade/mock/nodeStatusProcessorStub.go
+++ b/facade/mock/nodeStatusProcessorStub.go
@@ -1,6 +1,9 @@
 package mock
 
-import "github.com/multiversx/mx-chain-proxy-go/data"
+import (
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-proxy-go/data"
+)
 
 // NodeStatusProcessorStub --
 type NodeStatusProcessorStub struct {
@@ -19,7 +22,7 @@ type NodeStatusProcessorStub struct {
 	GetGasConfigsCalled                             func() (*data.GenericAPIResponse, error)
 	GetTriesStatisticsCalled                        func(shardID uint32) (*data.TrieStatisticsAPIResponse, error)
 	GetEpochStartDataCalled                         func(epoch uint32, shardID uint32) (*data.GenericAPIResponse, error)
-	GetTransactionsPoolCountCalled                  func(shardID uint32) (uint64, error)
+	GetTransactionsPoolCountsCalled                 func(shardIDParam core.OptionalUint32) (map[uint32]uint64, error)
 }
 
 // GetNetworkConfigMetrics --
@@ -156,10 +159,10 @@ func (stub *NodeStatusProcessorStub) GetTriesStatistics(shardID uint32) (*data.T
 	return &data.TrieStatisticsAPIResponse{}, nil
 }
 
-// GetTransactionsPoolCount -
-func (stub *NodeStatusProcessorStub) GetTransactionsPoolCount(shardID uint32) (uint64, error) {
-	if stub.GetTransactionsPoolCountCalled != nil {
-		return stub.GetTransactionsPoolCountCalled(shardID)
+// GetTransactionsPoolCounts -
+func (stub *NodeStatusProcessorStub) GetTransactionsPoolCounts(shardIDParam core.OptionalUint32) (map[uint32]uint64, error) {
+	if stub.GetTransactionsPoolCountsCalled != nil {
+		return stub.GetTransactionsPoolCountsCalled(shardIDParam)
 	}
-	return 0, nil
+	return make(map[uint32]uint64), nil
 }

--- a/process/nodeStatusProcessor.go
+++ b/process/nodeStatusProcessor.go
@@ -376,11 +376,42 @@ func (nsp *NodeStatusProcessor) GetTriesStatistics(shardID uint32) (*data.TrieSt
 	return getTrieStatistics(nodeStatusResponse.Data)
 }
 
-// GetTransactionsPoolCount will return the number of transactions currently in the pool for the given shard
-func (nsp *NodeStatusProcessor) GetTransactionsPoolCount(shardID uint32) (uint64, error) {
+// GetTransactionsPoolCounts will return the number of transactions currently in the pool.
+// If shardIDParam has a value, it returns the count only for the provided shard,
+// otherwise it returns the counts for every shard.
+func (nsp *NodeStatusProcessor) GetTransactionsPoolCounts(shardIDParam core.OptionalUint32) (map[uint32]uint64, error) {
+	shardsIDs := make(map[uint32]struct{})
+	if shardIDParam.HasValue {
+		shardsIDs[shardIDParam.Value] = struct{}{}
+	} else {
+		var err error
+		shardsIDs, err = nsp.getShardsIDs()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	counts := make(map[uint32]uint64, len(shardsIDs))
+	for shardID := range shardsIDs {
+		count, err := nsp.getTransactionsPoolCountForShard(shardID)
+		if err != nil {
+			return nil, err
+		}
+
+		counts[shardID] = count
+	}
+
+	return counts, nil
+}
+
+func (nsp *NodeStatusProcessor) getTransactionsPoolCountForShard(shardID uint32) (uint64, error) {
 	nodeStatusResponse, err := nsp.getNodeStatusMetrics(shardID)
 	if err != nil {
 		return 0, err
+	}
+
+	if nodeStatusResponse.Error != "" {
+		return 0, errors.New(nodeStatusResponse.Error)
 	}
 
 	return getTransactionsPoolCount(nodeStatusResponse.Data)

--- a/process/nodeStatusProcessor.go
+++ b/process/nodeStatusProcessor.go
@@ -62,6 +62,9 @@ const (
 
 	// MetricNonce is the metric for monitoring the nonce of a node
 	MetricNonce = "erd_nonce"
+
+	// MetricTxPoolLoad is the metric for monitoring the number of transactions currently in the pool
+	MetricTxPoolLoad = "erd_tx_pool_load"
 )
 
 // NodeStatusProcessor handles the action needed for fetching data related to status metrics from nodes
@@ -373,6 +376,16 @@ func (nsp *NodeStatusProcessor) GetTriesStatistics(shardID uint32) (*data.TrieSt
 	return getTrieStatistics(nodeStatusResponse.Data)
 }
 
+// GetTransactionsPoolCount will return the number of transactions currently in the pool for the given shard
+func (nsp *NodeStatusProcessor) GetTransactionsPoolCount(shardID uint32) (uint64, error) {
+	nodeStatusResponse, err := nsp.getNodeStatusMetrics(shardID)
+	if err != nil {
+		return 0, err
+	}
+
+	return getTransactionsPoolCount(nodeStatusResponse.Data)
+}
+
 func getMinNonce(noncesSlice []uint64) uint64 {
 	// initialize min with max uint64 value
 	min := uint64(math.MaxUint64)
@@ -430,6 +443,15 @@ func getTrieStatistics(nodeStatusData interface{}) (*data.TrieStatisticsAPIRespo
 
 	trieStatistics.Data.AccountsSnapshotNumNodes = getUint(numNodesMetric)
 	return trieStatistics, nil
+}
+
+func getTransactionsPoolCount(nodeStatusData interface{}) (uint64, error) {
+	txPoolLoadMetric, ok := getMetric(nodeStatusData, MetricTxPoolLoad)
+	if !ok {
+		return 0, ErrCannotParseNodeStatusMetrics
+	}
+
+	return getUint(txPoolLoadMetric), nil
 }
 
 func getMetric(nodeStatusData interface{}, metric string) (interface{}, bool) {

--- a/process/nodeStatusProcessor_test.go
+++ b/process/nodeStatusProcessor_test.go
@@ -860,6 +860,110 @@ func TestNodeStatusProcessor_GetTriesStatistics(t *testing.T) {
 	})
 }
 
+func TestNodeStatusProcessor_GetTransactionsPoolCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("get observers error", func(t *testing.T) {
+		t.Parallel()
+
+		localErr := errors.New("local error")
+		nodeStatusProc, _ := NewNodeStatusProcessor(&mock.ProcessorStub{
+			GetObserversCalled: func(shardId uint32, _ data.ObserverDataAvailabilityType) (observers []*data.NodeData, err error) {
+				return nil, localErr
+			},
+		},
+			&mock.GenericApiResponseCacherMock{},
+			time.Second,
+		)
+
+		count, err := nodeStatusProc.GetTransactionsPoolCount(0)
+		require.Equal(t, uint64(0), count)
+		require.Equal(t, localErr, err)
+	})
+	t.Run("error sending request", func(t *testing.T) {
+		t.Parallel()
+
+		nodeStatusProc, _ := NewNodeStatusProcessor(&mock.ProcessorStub{
+			GetObserversCalled: func(shardId uint32, dataAvailability data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+				return []*data.NodeData{
+					{Address: "address1", ShardId: 0},
+				}, nil
+			},
+			CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
+				return 0, errors.New("endpoint error")
+			},
+		},
+			&mock.GenericApiResponseCacherMock{},
+			time.Second,
+		)
+
+		count, err := nodeStatusProc.GetTransactionsPoolCount(0)
+		require.Equal(t, uint64(0), count)
+		require.True(t, errors.Is(err, ErrSendingRequest))
+	})
+	t.Run("missing metric from response", func(t *testing.T) {
+		t.Parallel()
+
+		nodeStatusProc, _ := NewNodeStatusProcessor(&mock.ProcessorStub{
+			GetObserversCalled: func(shardId uint32, dataAvailability data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+				return []*data.NodeData{
+					{Address: "address1", ShardId: 0},
+				}, nil
+			},
+			CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
+				localMap := map[string]interface{}{
+					"metrics": map[string]interface{}{},
+				}
+
+				genericResp := &data.GenericAPIResponse{Data: localMap}
+				genRespBytes, _ := json.Marshal(genericResp)
+
+				return 0, json.Unmarshal(genRespBytes, value)
+			},
+		},
+			&mock.GenericApiResponseCacherMock{},
+			time.Second,
+		)
+
+		count, err := nodeStatusProc.GetTransactionsPoolCount(0)
+		require.Equal(t, uint64(0), count)
+		require.Equal(t, ErrCannotParseNodeStatusMetrics, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		providedCount := uint64(42)
+		nodeStatusProc, _ := NewNodeStatusProcessor(&mock.ProcessorStub{
+			GetObserversCalled: func(shardId uint32, dataAvailability data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+				require.Equal(t, uint32(1), shardId)
+				return []*data.NodeData{
+					{Address: "address1", ShardId: 1},
+				}, nil
+			},
+			CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
+				require.Equal(t, "/node/status", path)
+				localMap := map[string]interface{}{
+					"metrics": map[string]interface{}{
+						"erd_tx_pool_load": float64(providedCount),
+					},
+				}
+
+				genericResp := &data.GenericAPIResponse{Data: localMap}
+				genRespBytes, _ := json.Marshal(genericResp)
+
+				return 0, json.Unmarshal(genRespBytes, value)
+			},
+		},
+			&mock.GenericApiResponseCacherMock{},
+			time.Nanosecond,
+		)
+
+		count, err := nodeStatusProc.GetTransactionsPoolCount(1)
+		require.NoError(t, err)
+		require.Equal(t, providedCount, count)
+	})
+}
+
 func TestNodeStatusProcessor_GetEpochStartData(t *testing.T) {
 	t.Parallel()
 

--- a/process/nodeStatusProcessor_test.go
+++ b/process/nodeStatusProcessor_test.go
@@ -860,14 +860,35 @@ func TestNodeStatusProcessor_GetTriesStatistics(t *testing.T) {
 	})
 }
 
-func TestNodeStatusProcessor_GetTransactionsPoolCount(t *testing.T) {
+func TestNodeStatusProcessor_GetTransactionsPoolCounts(t *testing.T) {
 	t.Parallel()
 
-	t.Run("get observers error", func(t *testing.T) {
+	t.Run("get all observers error", func(t *testing.T) {
 		t.Parallel()
 
 		localErr := errors.New("local error")
 		nodeStatusProc, _ := NewNodeStatusProcessor(&mock.ProcessorStub{
+			GetAllObserversCalled: func(_ data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+				return nil, localErr
+			},
+		},
+			&mock.GenericApiResponseCacherMock{},
+			time.Second,
+		)
+
+		counts, err := nodeStatusProc.GetTransactionsPoolCounts(core.OptionalUint32{})
+		require.Nil(t, counts)
+		require.Equal(t, localErr, err)
+	})
+	t.Run("get observers error for filtered shard", func(t *testing.T) {
+		t.Parallel()
+
+		localErr := errors.New("local error")
+		nodeStatusProc, _ := NewNodeStatusProcessor(&mock.ProcessorStub{
+			GetAllObserversCalled: func(_ data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+				require.Fail(t, "should not fetch all observers when shard filter is provided")
+				return nil, nil
+			},
 			GetObserversCalled: func(shardId uint32, _ data.ObserverDataAvailabilityType) (observers []*data.NodeData, err error) {
 				return nil, localErr
 			},
@@ -876,17 +897,23 @@ func TestNodeStatusProcessor_GetTransactionsPoolCount(t *testing.T) {
 			time.Second,
 		)
 
-		count, err := nodeStatusProc.GetTransactionsPoolCount(0)
-		require.Equal(t, uint64(0), count)
+		counts, err := nodeStatusProc.GetTransactionsPoolCounts(core.OptionalUint32{Value: 1, HasValue: true})
+		require.Nil(t, counts)
 		require.Equal(t, localErr, err)
 	})
-	t.Run("error sending request", func(t *testing.T) {
+	t.Run("error sending request should fail all", func(t *testing.T) {
 		t.Parallel()
 
 		nodeStatusProc, _ := NewNodeStatusProcessor(&mock.ProcessorStub{
-			GetObserversCalled: func(shardId uint32, dataAvailability data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+			GetAllObserversCalled: func(_ data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
 				return []*data.NodeData{
 					{Address: "address1", ShardId: 0},
+					{Address: "address2", ShardId: 1},
+				}, nil
+			},
+			GetObserversCalled: func(shardId uint32, _ data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+				return []*data.NodeData{
+					{Address: "address1", ShardId: shardId},
 				}, nil
 			},
 			CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
@@ -897,15 +924,20 @@ func TestNodeStatusProcessor_GetTransactionsPoolCount(t *testing.T) {
 			time.Second,
 		)
 
-		count, err := nodeStatusProc.GetTransactionsPoolCount(0)
-		require.Equal(t, uint64(0), count)
+		counts, err := nodeStatusProc.GetTransactionsPoolCounts(core.OptionalUint32{})
+		require.Nil(t, counts)
 		require.True(t, errors.Is(err, ErrSendingRequest))
 	})
-	t.Run("missing metric from response", func(t *testing.T) {
+	t.Run("missing metric from response should fail all", func(t *testing.T) {
 		t.Parallel()
 
 		nodeStatusProc, _ := NewNodeStatusProcessor(&mock.ProcessorStub{
-			GetObserversCalled: func(shardId uint32, dataAvailability data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+			GetAllObserversCalled: func(_ data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+				return []*data.NodeData{
+					{Address: "address1", ShardId: 0},
+				}, nil
+			},
+			GetObserversCalled: func(shardId uint32, _ data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
 				return []*data.NodeData{
 					{Address: "address1", ShardId: 0},
 				}, nil
@@ -925,26 +957,35 @@ func TestNodeStatusProcessor_GetTransactionsPoolCount(t *testing.T) {
 			time.Second,
 		)
 
-		count, err := nodeStatusProc.GetTransactionsPoolCount(0)
-		require.Equal(t, uint64(0), count)
+		counts, err := nodeStatusProc.GetTransactionsPoolCounts(core.OptionalUint32{})
+		require.Nil(t, counts)
 		require.Equal(t, ErrCannotParseNodeStatusMetrics, err)
 	})
-	t.Run("should work", func(t *testing.T) {
+	t.Run("should work for every shard", func(t *testing.T) {
 		t.Parallel()
 
-		providedCount := uint64(42)
+		countsByAddress := map[string]uint64{
+			"address0": 10,
+			"address1": 42,
+		}
 		nodeStatusProc, _ := NewNodeStatusProcessor(&mock.ProcessorStub{
-			GetObserversCalled: func(shardId uint32, dataAvailability data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
-				require.Equal(t, uint32(1), shardId)
+			GetAllObserversCalled: func(_ data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
 				return []*data.NodeData{
+					{Address: "address0", ShardId: 0},
 					{Address: "address1", ShardId: 1},
 				}, nil
+			},
+			GetObserversCalled: func(shardId uint32, _ data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+				if shardId == 0 {
+					return []*data.NodeData{{Address: "address0", ShardId: 0}}, nil
+				}
+				return []*data.NodeData{{Address: "address1", ShardId: 1}}, nil
 			},
 			CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
 				require.Equal(t, "/node/status", path)
 				localMap := map[string]interface{}{
 					"metrics": map[string]interface{}{
-						"erd_tx_pool_load": float64(providedCount),
+						"erd_tx_pool_load": float64(countsByAddress[address]),
 					},
 				}
 
@@ -958,9 +999,45 @@ func TestNodeStatusProcessor_GetTransactionsPoolCount(t *testing.T) {
 			time.Nanosecond,
 		)
 
-		count, err := nodeStatusProc.GetTransactionsPoolCount(1)
+		counts, err := nodeStatusProc.GetTransactionsPoolCounts(core.OptionalUint32{})
 		require.NoError(t, err)
-		require.Equal(t, providedCount, count)
+		require.Equal(t, map[uint32]uint64{0: 10, 1: 42}, counts)
+	})
+	t.Run("should work for filtered shard only", func(t *testing.T) {
+		t.Parallel()
+
+		nodeStatusProc, _ := NewNodeStatusProcessor(&mock.ProcessorStub{
+			GetAllObserversCalled: func(_ data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+				require.Fail(t, "should not fetch all observers when shard filter is provided")
+				return nil, nil
+			},
+			GetObserversCalled: func(shardId uint32, _ data.ObserverDataAvailabilityType) ([]*data.NodeData, error) {
+				require.Equal(t, uint32(1), shardId)
+				return []*data.NodeData{
+					{Address: "address1", ShardId: 1},
+				}, nil
+			},
+			CallGetRestEndPointCalled: func(address string, path string, value interface{}) (int, error) {
+				require.Equal(t, "/node/status", path)
+				localMap := map[string]interface{}{
+					"metrics": map[string]interface{}{
+						"erd_tx_pool_load": float64(42),
+					},
+				}
+
+				genericResp := &data.GenericAPIResponse{Data: localMap}
+				genRespBytes, _ := json.Marshal(genericResp)
+
+				return 0, json.Unmarshal(genRespBytes, value)
+			},
+		},
+			&mock.GenericApiResponseCacherMock{},
+			time.Nanosecond,
+		)
+
+		counts, err := nodeStatusProc.GetTransactionsPoolCounts(core.OptionalUint32{Value: 1, HasValue: true})
+		require.NoError(t, err)
+		require.Equal(t, map[uint32]uint64{1: 42}, counts)
 	})
 }
 


### PR DESCRIPTION
- Adds GET `/transaction/pool/count?shard-id={shard}.`
- Returns the number of transactions currently in the pool for the given shard. Resolves an observer for shard-id (required, uint32, same parseUint32UrlParam as /transaction/pool), calls observer GET /node/status, extracts erd_tx_pool_load.
- Also a fix was required here: https://github.com/multiversx/mx-chain-go/pull/8008